### PR TITLE
✨ Add full_filepath option to fetch_bucket_obj_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,6 @@ contents = fetch_bucket_obj_info(
 )
 ```
 
-#### Remove Path names from the keys of the returned objects
-
-You can return the name of each object without the path name by setting `drop_path=True`. 
-
-```python
-contents = fetch_bucket_obj_info(
-  "kf-study-us-east-1-dev-sd-me0wme0w",
-  "source/pics/",
-  drop_path=True
-)
-```
-
 #### Write the contents to a delimited file
 
 ```python

--- a/d3b_utils/aws_bucket_contents.py
+++ b/d3b_utils/aws_bucket_contents.py
@@ -3,12 +3,10 @@ import re
 import csv
 from itertools import chain
 
-
 def fetch_bucket_obj_info(
     bucket_name,
     search_prefixes=None,
     drop_folders=False,
-    drop_path=False,
     output_filename=None,
     delim=None,
 ):
@@ -26,9 +24,6 @@ def fetch_bucket_obj_info(
     :type search_prefixes: str, list
     :param drop_folders: Drops folders from the list of returned objects.
         This is done by removing objects where `Size = 0`. Default is
-        False.
-    :type drop_folders: bool, optional
-    :param drop_path: Drops the path names to each object. Default is
         False.
     :type drop_folders: bool, optional
     :param output_filename: If provided, write delimited results to this file
@@ -64,14 +59,12 @@ def fetch_bucket_obj_info(
             object for object in bucket_contents if object["Size"] > 0
         ]
 
-    if drop_path:
-        for object in bucket_contents:
-            _, _, object["Key"] = object["Key"].rpartition("/")
-
     for object in bucket_contents:
         object["Bucket"] = bucket_name
         # ETag comes back with unnecessary quotation marks, so strip them
         object["ETag"] = object["ETag"].strip('"')
+        object["Filepath"] = f"s3://{bucket_name}/{object['Key']}"
+        *_, object["Filename"] = object["Key"].rpartition("/")
 
     # Write to file
     if output_filename:


### PR DESCRIPTION
Allows the user to obtain a full_filepath key/value pair in the dictionaries returned by the `fetch_bucket_obj_info` function. This provides the full s3 path for the object in question. The `full_filepath` param controls this and defaults to `False`. 

When the full filepaths are needed, this is a cleaner solution than iterating over the resultant list (again) and creating the desired key/value pair.