### PR TITLE
⏪ Revert "Add full_filepath option to fetch_bucket_obj_info"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,21 @@ Before using these functions, make sure to authenticate. Use [`chopaws`](https:/
 from d3b_utils.aws_bucket_contents import fetch_bucket_obj_info
 ```
 
-#### list the items in a bucket
+#### List the items in a bucket
 
 ```python
 contents = fetch_bucket_obj_info(
   "kf-study-us-east-1-dev-sd-me0wme0w",
-  "source/pics/"
+  search_prefixes="source/pics/"
 )
 ```
 
-#### list the items in multiple folders in a bucket
+#### List the items in multiple folders in a bucket
 
 ```python
 contents = fetch_bucket_obj_info(
   "kf-study-us-east-1-dev-sd-me0wme0w",
-  ["source/pics/", "source/uploads/"]
+  search_prefixes=["source/pics/", "source/uploads/"]
 )
 ```
 
@@ -59,7 +59,6 @@ The list of returned objects includes folders. You can drop the folders by setti
 ```python
 contents = fetch_bucket_obj_info(
   "kf-study-us-east-1-dev-sd-me0wme0w",
-  "source/pics/",
   drop_folders=True,
 )
 ```
@@ -69,7 +68,7 @@ contents = fetch_bucket_obj_info(
 ```python
 contents = fetch_bucket_obj_info(
   "kf-study-us-east-1-dev-sd-me0wme0w",
-  "source/pics/",
+  search_prefixes="source/pics/",
   drop_folders=True,
   output_filename="my_bucket_contents.tsv"
 )
@@ -82,7 +81,6 @@ Specify the profile name. If not authenticating with `chopaws`, set the profile 
 ```python
 contents = fetch_bucket_obj_info(
   "kf-study-us-east-1-dev-sd-me0wme0w",
-  "source/pics/",
   profile="user1"
 )
 ```

--- a/d3b_utils/aws_bucket_contents.py
+++ b/d3b_utils/aws_bucket_contents.py
@@ -3,6 +3,7 @@ import re
 import csv
 from itertools import chain
 
+
 def fetch_bucket_obj_info(
     bucket_name,
     search_prefixes=None,
@@ -59,15 +60,14 @@ def fetch_bucket_obj_info(
 
     if drop_folders:
         bucket_contents = [
-            object for object in bucket_contents if object["Size"] > 0
+            object for object in bucket_contents 
+            if ((object["Key"][-1] != "/") or (object["Size"] > 0))
         ]
 
     for object in bucket_contents:
         object["Bucket"] = bucket_name
         # ETag comes back with unnecessary quotation marks, so strip them
         object["ETag"] = object["ETag"].strip('"')
-        object["Filepath"] = f"s3://{bucket_name}/{object['Key']}"
-        *_, object["Filename"] = object["Key"].rpartition("/")
 
     # Write to file
     if output_filename:


### PR DESCRIPTION
Reverts d3b-center/d3b-utils-python#7

It turns out I hate this and want to revert it. It explodes the output with redundant information. Can we talk about the motivation for wanting it in the first place?