### PR TITLE
:sparkles: add function to test connection to postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,18 @@ contents = fetch_obj_list_info(
   all_versions=False
 )
 ```
+
+## Test connection to a postgres database
+
+```python
+from d3b_utils.database import test_pg_connection
+
+db_url = "postgresql://username:password@localhost:5432/postgres"
+
+if test_pg_connection(db_url):
+  print("Able to connect to postgres")
+else:
+  print("Unable to connect to database")
+```
+
+Test if it's possible to connect to a postgres database. Useful if your script needs to do different things depending on if it's possible to connect to the postgres database of interest. Is usefull because psycopg2 will retry connecting for an extended amount of time if there are issues with conection to the database.

--- a/d3b_utils/database.py
+++ b/d3b_utils/database.py
@@ -1,0 +1,17 @@
+import psycopg2
+
+
+def test_pg_connection(db_url):
+    """Check if it is possible to connect to a postgres database
+
+    :param db_url: database url to attempt to connect to
+    :type db_url: str
+    :return: outcome of if it is possible to connect to the specified database
+    :rtype: bool
+    """
+    try:
+        conn = psycopg2.connect(db_url, connect_timeout=1)
+        conn.close()
+        return True
+    except psycopg2.OperationalError:
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 urllib3
 requests
 boto3
+psycopg2-binary


### PR DESCRIPTION
- [x] README entry added if new functionality

# Add function to test connection to postgres

Adds a function that returns a bool for whether or not it's possible to connect to the database in question. 

When psycopg2 can't connect to a database, it doesn't immediately fail but continues to retry for an extended period of time. So, instead of waiting for psycopg2 to return an error that is unclear in 10 minutes, just stop your script if it isn't possible to connect to the postgres db. 
