### PR TITLE
Sort column keys before writing

### DIFF
--- a/d3b_utils/s3_contents.py
+++ b/d3b_utils/s3_contents.py
@@ -21,7 +21,7 @@ def _s3meta_to_file(data, output_filename, delim):
     """Write results to files"""
 
     def _write(content, output_filename, delim):
-        keys = set(chain(*(d.keys() for d in content)))
+        keys = sorted(set(chain(*(d.keys() for d in content))))
         with open(output_filename, "w") as f:
             w = csv.DictWriter(f, restval="", fieldnames=keys, delimiter=delim)
             w.writeheader()


### PR DESCRIPTION
Otherwise the set randomizes their order and makes files from subsequent runs a little harder to compare with column-unaware diff tools.

closes #25

